### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/aiw-devops/e1b7a520-0354-4694-b283-5642d3be6307/2f405538-61ce-46f9-a0de-e7611d8cc4f2/_apis/work/boardbadge/769ef3a7-255e-4fae-b89b-626cc5a24714)](https://dev.azure.com/aiw-devops/e1b7a520-0354-4694-b283-5642d3be6307/_boards/board/t/2f405538-61ce-46f9-a0de-e7611d8cc4f2/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1887](https://dev.azure.com/aiw-devops/e1b7a520-0354-4694-b283-5642d3be6307/_workitems/edit/1887). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.